### PR TITLE
ロード画面の表示＋スタート画面の表示 ＋ デザインの変更 ＋ ゲーム画面とランキング画面を切り替えられるように

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -86,8 +86,17 @@ button {
     margin-bottom: 10px;
   }
   .button-description {
-    margin-top: 20px;
+    margin-top: 10px;
     font-size: 30px;
+  }
+
+  .loading-screen{
+    position: absolute;
+    display: none;
+    width: 100%;
+    height: 100%;
+    margin-top: 50%;
+    font-size: 80px;
   }
 
 
@@ -149,6 +158,7 @@ button {
     display: inline-block;
     position: relative;
     margin-top: 30px;
+    margin-bottom: 0px;
     z-index: 0;
   }
 
@@ -276,6 +286,15 @@ button {
   }
   .button-description {
     font-size: 18px;
+  }
+
+  .loading-screen{
+    position: absolute;
+    display: none;
+    width: 100%;
+    height: 100%;
+    margin-top: 50%;
+    font-size: 40px;
   }
 
   .result-title {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -94,7 +94,7 @@ button {
     position: absolute;
     width: 100%;
     height: 40%;
-    margin-top: 30%;
+    margin-top: 50%;
   }
 
   #start-button{
@@ -111,10 +111,11 @@ button {
   .loading-screen{
     position: absolute;
     display: none;
-    width: 100%;
-    height: 100%;
-    margin-top: 50%;
-    font-size: 80px;
+    width: 50%;
+    height: 50%;
+    margin-top: 3%;
+    margin-left: 60%;
+    font-size: 40px;
   }
 
 
@@ -327,11 +328,13 @@ button {
   .loading-screen{
     position: absolute;
     display: none;
-    width: 100%;
-    height: 100%;
-    margin-top: 50%;
-    font-size: 40px;
+    width: 50%;
+    height: 50%;
+    margin-top: 3%;
+    margin-left: 60%;
+    font-size: 20px;
   }
+
 
   .result-title {
     margin-top: 25px;

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -3,6 +3,8 @@
 body {
   height: 100%;
   width: 100%;
+  overflow-x: hidden;
+  overflow-y: scroll;
   background-color: #262544;
   margin: 10;
   padding: 10;
@@ -14,6 +16,10 @@ body {
 button {
   font-family: "Quicksand", sans-serif;
   font-weight: medium;
+}
+
+.pressed-buttons-color {
+  background-color: #CEB845 !important;
 }
 
 .container {
@@ -75,10 +81,6 @@ button {
 
 @media screen{
   /*　for iPhone */
-  .body{
-    overflow-x: hidden;
-    overflow-y: hidden;
-  }
 
   .title {
     display: inline-block;
@@ -94,8 +96,9 @@ button {
   .start-screen{
     position: absolute;
     width: 100%;
-    height: 40%;
-    margin-top: 50%;
+    height: 100%;
+    margin-top: 0px;
+    background-color: rgba(255,255,255, 0.15);
   }
 
   #start-button{
@@ -109,6 +112,7 @@ button {
     background-color: #FFFFFF;
     border-color: #262544;
     border-width: 1px;
+    margin-top: 50%;
   }
 
   .loading-screen{
@@ -244,7 +248,7 @@ button {
     font-size: 60px;
   }
 
-  #restart-button {
+  #game-button {
     font-size: 40px;
     color: #FFFFFF;
     border: 5px solid #FFFFFF;
@@ -274,7 +278,7 @@ button {
     margin-left: 30px;
   }
 
-  .start_ranking_buttons {
+  .game_ranking_buttons {
     float: left;
   }
 
@@ -310,10 +314,7 @@ button {
 
 @media screen and (min-width: 1024px) {
   /*　for PC　*/
-  .body{
-    overflow-x: hidden;
-    overflow-y: scroll;
-    }
+
   .title {
     display: inline-block;
     position: relative;
@@ -327,8 +328,9 @@ button {
   .start-screen{
     position: absolute;
     width: 100%;
-    height: 50%;
-    margin-top: 50%;
+    height: 100%;
+    margin-top: 0px;
+    background-color: rgba(255,255,255, 0.15);
   }
 
   #start-button{
@@ -340,6 +342,7 @@ button {
     background-color: #FFFFFF;
     border-color: #FFFFFF;
     border-width: 1px;
+    margin-top: 50%;
   }
 
   .loading-screen{
@@ -464,7 +467,7 @@ button {
     font-size: 45px;
   }
 
-  #restart-button {
+  #game-button {
     font-size: 14px;
     color: #FFFFFF;
     border: 2px solid #FFFFFF;

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -94,7 +94,7 @@ button {
     position: absolute;
     width: 100%;
     height: 40%;
-    margin-top: 50%;
+    margin-top: 30%;
   }
 
   #start-button{

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -90,6 +90,24 @@ button {
     font-size: 30px;
   }
 
+  .start-screen{
+    position: absolute;
+    width: 100%;
+    height: 40%;
+    margin-top: 50%;
+  }
+
+  #start-button{
+    font-size: 80px;
+    font-weight: lighter;
+    border-radius: 50px;
+    width: 50%;
+    color: #FFFFFF;
+    background-color: #262544;
+    border-color: #FFFFFF;
+    border-width: 1px;
+  }
+
   .loading-screen{
     position: absolute;
     display: none;
@@ -218,7 +236,7 @@ button {
     font-size: 60px;
   }
 
-  #start-button {
+  #restart-button {
     font-size: 40px;
     display: block;
     width: 240px;
@@ -286,6 +304,24 @@ button {
   }
   .button-description {
     font-size: 18px;
+  }
+
+  .start-screen{
+    position: absolute;
+    width: 100%;
+    height: 50%;
+    margin-top: 50%;
+  }
+
+  #start-button{
+    font-size: 40px;
+    font-weight: lighter;
+    border-radius: 50px;
+    width: 50%;
+    color: #FFFFFF;
+    background-color: #262544;
+    border-color: #FFFFFF;
+    border-width: 1px;
   }
 
   .loading-screen{
@@ -405,7 +441,7 @@ button {
     font-size: 45px;
   }
 
-  #start-button {
+  #restart-button {
     font-size: 13px;
     width: 80px;
     height: 40px;

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -75,8 +75,9 @@ button {
 
 @media screen{
   /*　for iPhone */
-  body{
-    overflow: hidden;
+  .body{
+    overflow-x: hidden;
+    overflow-y: hidden;
   }
 
   .title {
@@ -99,12 +100,14 @@ button {
 
   #start-button{
     font-size: 80px;
+    font-weight: 700;
+    border: 2px solid #FFFFFF;
     font-weight: lighter;
     border-radius: 50px;
     width: 50%;
-    color: #FFFFFF;
-    background-color: #262544;
-    border-color: #FFFFFF;
+    color: #262544;
+    background-color: #FFFFFF;
+    border-color: #262544;
     border-width: 1px;
   }
 
@@ -190,6 +193,10 @@ button {
   }
   .rl-selection-button-container button {
     font-size: 30px;
+    color: #FFFFFF;
+    border: 2px solid #FFFFFF;
+    border-width: 5px;
+    background-color: #262544;
     width: 200px;
     height: 80px;
     line-height: 70px;
@@ -239,6 +246,9 @@ button {
 
   #restart-button {
     font-size: 40px;
+    color: #FFFFFF;
+    border: 5px solid #FFFFFF;
+    background-color: #262544;
     display: block;
     width: 240px;
     height: 100px;
@@ -251,6 +261,9 @@ button {
 
   #ranking-button {
     font-size: 40px;
+    color: #FFFFFF;
+    border: 5px solid #FFFFFF;
+    background-color: #262544;
     display: block;
     width: 240px;
     height: 100px;
@@ -297,6 +310,10 @@ button {
 
 @media screen and (min-width: 1024px) {
   /*　for PC　*/
+  .body{
+    overflow-x: hidden;
+    overflow-y: scroll;
+    }
   .title {
     display: inline-block;
     position: relative;
@@ -315,12 +332,12 @@ button {
   }
 
   #start-button{
-    font-size: 40px;
-    font-weight: lighter;
-    border-radius: 50px;
-    width: 50%;
-    color: #FFFFFF;
-    background-color: #262544;
+    font-size: 35px;
+    font-weight: 500;
+    border-radius: 20px;
+    width: 45%;
+    color: #262544;
+    background-color: #FFFFFF;
     border-color: #FFFFFF;
     border-width: 1px;
   }
@@ -397,11 +414,14 @@ button {
     margin: 10px 0;
   }
   .rl-selection-button-container button {
-    font-size: 13px;
+    font-size: 14px;
+    color: #FFFFFF;
+    border: 3px solid #FFFFFF;
+    background-color: #262544;
     width: 80px;
     height: 40px;
     line-height: 35px;
-    border-radius: 20px;
+    border-radius: 10px;
   }
 
   table {
@@ -445,52 +465,68 @@ button {
   }
 
   #restart-button {
-    font-size: 13px;
-    width: 80px;
-    height: 40px;
+    font-size: 14px;
+    color: #FFFFFF;
+    border: 2px solid #FFFFFF;
+    border-width:3px 0px 3px 3px;
+    background-color: #262544;
+    width: 85px;
+    height: 45px;
     line-height: 35px;
-    border-radius: 20px;
     float: left;
-    margin-right: 10px;
-    margin-left: 20px;
-    margin-top: 5px;
+    margin-right: 0px;
+    margin-left: 0px;
+    margin-top: 0px;
+    border-top-left-radius: 10px;
+    border-bottom-left-radius: 10px;
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
   }
 
   #ranking-button {
-    font-size: 13px;
-    width: 80px;
-    height: 40px;
+    font-size: 14px;
+    color: #FFFFFF;
+    border: 2px solid #FFFFFF;
+    border-width: 3px;
+    background-color: #262544;
+    width: 85px;
+    height: 45px;
     line-height: 35px;
-    border-radius: 20px;
     float: left;
-    margin-right: 20px;
-    margin-left: 10px;
-    margin-top: 5px;
+    margin-right: 0px;
+    margin-left: 0px;
+    margin-top: 0px;
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+    border-top-right-radius: 10px;
+    border-bottom-right-radius: 10px;
   }
 
   .right-key {
     width: 0;
     height: 0;
-    border-left: 40px solid white;
-    border-top: 20px solid transparent;
-    border-bottom: 20px solid transparent;
+    border-left: 45px solid white;
+    border-top: 25px solid transparent;
+    border-bottom: 25px solid transparent;
     float: left;
-    margin-top: 7px;
+    margin-top: 0px;
+    margin-left: 40px;
   }
   .right-key-color {
-    border-left: 40px solid #628da5;
+    border-left: 45px solid #628da5;
   }
 
   .left-key {
     width: 0;
     height: 0;
-    border-right: 40px solid white;
-    border-top: 20px solid transparent;
-    border-bottom: 20px solid transparent;
+    border-right: 45px solid white;
+    border-top: 25px solid transparent;
+    border-bottom: 25px solid transparent;
     float: left;
-    margin-top: 7px;
+    margin-top: 0px;
+    margin-right: 40px;
   }
   .left-key-color {
-    border-right: 40px solid #628da5;
+    border-right: 45px solid #628da5;
   }
 }

--- a/client/index.html
+++ b/client/index.html
@@ -125,7 +125,7 @@
       <div class="key-area">
         <div class="left-key"></div>
         <div class="start_ranking_buttons">
-          <button id="restart-button">Restart</button>
+          <button id="restart-button">Game</button>
           <button id="ranking-button">Ranking</button>
         </div>
         <div class="right-key"></div>

--- a/client/index.html
+++ b/client/index.html
@@ -42,6 +42,9 @@
         </div>
 
         <div class="game">
+          <div class="loading-screen">
+            Loading...
+          </div>
           <div class="result-screen">
             <div class="result-title">Ranking</div>
             <div class="result-subtitle">(10,000 step)</div>

--- a/client/index.html
+++ b/client/index.html
@@ -124,8 +124,8 @@
 
       <div class="key-area">
         <div class="left-key"></div>
-        <div class="start_ranking_buttons">
-          <button id="restart-button">Game</button>
+        <div class="game_ranking_buttons">
+          <button id="game-button">Game</button>
           <button id="ranking-button">Ranking</button>
         </div>
         <div class="right-key"></div>

--- a/client/index.html
+++ b/client/index.html
@@ -45,6 +45,9 @@
           <div class="loading-screen">
             Loading...
           </div>
+          <div class="start-screen">
+            <button id="start-button">Start</button>
+          </div>
           <div class="result-screen">
             <div class="result-title">Ranking</div>
             <div class="result-subtitle">(10,000 step)</div>
@@ -122,7 +125,7 @@
       <div class="key-area">
         <div class="left-key"></div>
         <div class="start_ranking_buttons">
-          <button id="start-button">Start</button>
+          <button id="restart-button">Restart</button>
           <button id="ranking-button">Ranking</button>
         </div>
         <div class="right-key"></div>

--- a/client/js/frontend/gameScreen.js
+++ b/client/js/frontend/gameScreen.js
@@ -64,6 +64,11 @@ export class GameScreen {
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
   }
 
+  clearInsideCanvas() {
+    this.clearCanvas();
+    this.drawFrameBorder();
+  }
+
   // Redraw the game based on the current state
   async draw(state) {
 

--- a/client/js/frontend/main.js
+++ b/client/js/frontend/main.js
@@ -102,10 +102,13 @@ async function main(rlId) {
   let state = env.reset();
   scorer.draw();
 
+  // loading screen
+  $(".loading-screen").show();
   // load model
   const humanController = new KeyAgent();
   const rlController = new RLController(rlId);
   await rlController.warmUp();
+  $(".loading-screen").fadeOut();
 
   let timeStep = 0;
 

--- a/client/js/frontend/main.js
+++ b/client/js/frontend/main.js
@@ -113,12 +113,11 @@ async function main(rlId) {
   timer.start();
   while (true) {
     // monitor running flag
-    if ($.inArray(gameRunningState, [0, 1]) != -1) {
+    if ($.inArray(gameRunningState, [0, 1]) != -1 || timer.getRemTime() == 0) {
       gameRunningState = 0;
       break;
     }
 
-    
     const res = env.step({
       humanAction: humanController.selectAction(),
       rlAction: rlController.selectAction(state, timeStep),
@@ -188,7 +187,8 @@ $("#start-button").on("click", async function () {
 
   // start game
   gameRunningState = 2;
-  main(rlId);
+  await main(rlId);
+  $("#ranking-button").click();
 });
 
 // process for game button
@@ -209,7 +209,7 @@ $("#ranking-button").on("click", async function () {
   $("#game-button").prop("disabled", false);
   // wait until the game is over
   await stopGame();
-  
+
   // clear game screen
   initGameScreen.clearInsideCanvas();
   $(".start-screen").fadeOut();

--- a/client/js/frontend/main.js
+++ b/client/js/frontend/main.js
@@ -160,7 +160,6 @@ async function main(rlId) {
 $(document).ready(function () {
   // ボタンの初期状態
   const buttonId = "step-0k";
-  $(".rl-selection-button").css("background-color", "#FFFFFF");
   $("#" + buttonId).css("background-color", "#CEB845");
   $("#" + buttonId).prop("disabled", true);
 
@@ -177,7 +176,7 @@ $(".rl-selection-button").on("click", function () {
   $(".rl-selection-button").prop("disabled", false);
   // color
   const buttonId = $(this).attr("id");
-  $(".rl-selection-button").css("background-color", "#FFFFFF");
+  $(".rl-selection-button").css("background-color", "#262544");
   $("#" + buttonId).css("background-color", "#CEB845");
 
   $("#" + buttonId).prop("disabled", true);
@@ -214,4 +213,10 @@ $("#ranking-button").on("click", async function () {
     $("#restart-button").removeClass("first-click");
   }
   $(".result-screen").fadeIn();
+});
+
+//game and ranking button color
+$("#restart-button, #ranking-button").on("click", function () {
+  $("#restart-button, #ranking-button").css("background-color", "#262544");
+  $(this).css("background-color", "#CEB845");
 });

--- a/client/js/frontend/main.js
+++ b/client/js/frontend/main.js
@@ -166,7 +166,7 @@ $(document).ready(function () {
 
   // 初期ゲーム画面の描画
   const goalEffectInterval = 500;
-  new GameScreen(goalEffectInterval).drawFrameBorder();
+  new GameScreen(goalEffectInterval).draw(new PongRLEnv().reset());
 
   // load worker bundle in advance for better performance
   worker = new Worker("../../dist/worker.bundle.js");

--- a/client/js/frontend/main.js
+++ b/client/js/frontend/main.js
@@ -71,7 +71,7 @@ class RLController {
   }
 }
 
-async function waitUntilGameEnd() {
+async function stopGame() {
   if ($.inArray(gameRunningState, [1, 2]) != -1) {
     gameRunningState = 1;
     while (gameRunningState == 1) await sleep(80);
@@ -197,7 +197,7 @@ $("#game-button").on("click", async function () {
   $("#ranking-button").prop("disabled", false);
   $(".result-screen").fadeOut();
   // wait until the game is over
-  await waitUntilGameEnd();
+  await stopGame();
   // init game screen
   initGameScreen.draw(new PongRLEnv().reset());
   $(".start-screen").fadeIn();
@@ -208,7 +208,7 @@ $("#ranking-button").on("click", async function () {
   $("#ranking-button").prop("disabled", true);
   $("#game-button").prop("disabled", false);
   // wait until the game is over
-  await waitUntilGameEnd();
+  await stopGame();
   
   // clear game screen
   initGameScreen.clearInsideCanvas();

--- a/client/js/frontend/main.js
+++ b/client/js/frontend/main.js
@@ -113,11 +113,12 @@ async function main(rlId) {
   timer.start();
   while (true) {
     // monitor running flag
-    if (gameRunningState == 1) {
+    if ($.inArray(gameRunningState, [0, 1]) != -1) {
       gameRunningState = 0;
       break;
     }
 
+    
     const res = env.step({
       humanAction: humanController.selectAction(),
       rlAction: rlController.selectAction(state, timeStep),


### PR DESCRIPTION
以下の処理を追加

・restartからゲーム開始までロード画面になる
・初期状態でゲーム画面の真ん中にスタートボタンを配置
・デザインの変更
・ゲーム画面とランキング画面を切り替えられるように
・main.jsの終了フラグ条件のコードを改良

@TaiseiHashimoto 