### PR TITLE
DB接続の SSL を有効化

### DIFF
--- a/server/db/config/config.json
+++ b/server/db/config/config.json
@@ -5,6 +5,9 @@
   },
   "production": {
     "use_env_variable": "DATABASE_URL",
-    "dialect": "postgres"
+    "dialect": "postgres",
+    "dialectOptions": {
+      "ssl": true
+    }
   }
 }


### PR DESCRIPTION
Heroku 上で Postgres への接続時に SSL 有効化が必要だった。
現状ではエラーが出ているため、設定を修正する。
参考：
https://stackoverflow.com/questions/27687546/cant-connect-to-heroku-postgresql-database-from-local-node-app-with-sequelize