### PR TITLE
DB SSL 設定方法が古かったので更新

### DIFF
--- a/server/db/config/config.json
+++ b/server/db/config/config.json
@@ -7,7 +7,8 @@
     "use_env_variable": "DATABASE_URL",
     "dialect": "postgres",
     "dialectOptions": {
-      "ssl": true
+      "require": true,
+      "rejectUnauthorized": false
     }
   }
 }


### PR DESCRIPTION
最近設定方法が変わったらしく、現状ではエラーが出るので更新。
何度も申し訳ない。。
参考；
https://stackoverflow.com/questions/58965011/sequelizeconnectionerror-self-signed-certificate